### PR TITLE
Fix playing track when loading new track

### DIFF
--- a/app/hooks/useDjEngine.ts
+++ b/app/hooks/useDjEngine.ts
@@ -77,9 +77,12 @@ const useStore = create<DjStore>()(
         }
       },
       loadTrack: async (deckId, file) => {
-        if (get().players[deckId].isPlaying) {
-            playerNodes[deckId].source?.stop();
-        }
+        // Always stop and disconnect any currently playing source on this deck
+        // before loading the new track to avoid multiple tracks playing
+        // simultaneously.
+        playerNodes[deckId].source?.stop();
+        playerNodes[deckId].source?.disconnect();
+        playerNodes[deckId].source = null;
         const arrayBuffer = await file.arrayBuffer();
         const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
         const waveform = processAudioBuffer(audioBuffer);


### PR DESCRIPTION
## Summary
- ensure the current deck's audio node stops when loading a new track

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d76a5f62c832e9ea451bf524be660