### PR TITLE
Add pitch range options and jogwheel nudge

### DIFF
--- a/app/components/Player.tsx
+++ b/app/components/Player.tsx
@@ -13,7 +13,7 @@ interface PlayerProps {
 
 const Player: React.FC<PlayerProps> = ({ deckId, useStore }) => {
   const playerState = (useStore as any)((state: DjStore) => state.players[deckId]);
-  const { loadTrack, togglePlay, setPitch, setHotCue, jumpToHotCue, deleteHotCue, setLoop, clearLoop, toggleSync, syncPlayers } =
+  const { loadTrack, togglePlay, setPitch, setPitchRange, nudge, setHotCue, jumpToHotCue, deleteHotCue, setLoop, clearLoop, toggleSync, syncPlayers } =
     (useStore as any)((state: DjStore) => state.actions);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -32,7 +32,8 @@ const Player: React.FC<PlayerProps> = ({ deckId, useStore }) => {
   const deckColor = deckId === 0 ? 'cyan' : 'red';
 
   const handlePitchChange = (value: number) => {
-    const newPitch = 0.5 + value; // map 0-1 to 0.5-1.5
+    const range = playerState.pitchRange;
+    const newPitch = (1 - range) + value * (range * 2);
     setPitch(deckId, newPitch);
   };
 
@@ -51,10 +52,20 @@ const Player: React.FC<PlayerProps> = ({ deckId, useStore }) => {
         <JogWheel deckId={deckId} useStore={useStore} />
         <div className="h-48 flex flex-col items-center">
           <Fader
-            value={playerState.pitch - 0.5}
+            value={(playerState.pitch - (1 - playerState.pitchRange)) / (playerState.pitchRange * 2)}
             onChange={handlePitchChange}
             orientation="vertical"
           />
+          <div className="flex gap-1 mt-1">
+            <button
+              onClick={() => setPitchRange(deckId, 0.08)}
+              className={`px-1 text-xs rounded bg-gray-700 hover:bg-gray-600 text-${deckColor}-400`}
+            >8%</button>
+            <button
+              onClick={() => setPitchRange(deckId, 0.16)}
+              className={`px-1 text-xs rounded bg-gray-700 hover:bg-gray-600 text-${deckColor}-400`}
+            >16%</button>
+          </div>
           <span className={`text-xs font-bold mt-1 text-${deckColor}-400`}>Pitch</span>
         </div>
       </div>

--- a/app/components/player/JogWheel.tsx
+++ b/app/components/player/JogWheel.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import type { StoreApi } from 'zustand';
 import type { DjStore } from '../../types';
 
@@ -10,14 +10,37 @@ interface JogWheelProps {
 
 const JogWheel: React.FC<JogWheelProps> = ({ deckId, useStore }) => {
   const playerState = (useStore as any)((state: DjStore) => state.players[deckId]);
-  const { track, isPlaying, pitch } = playerState;
+  const { track, isPlaying, pitch, bpm } = playerState;
+  const { nudge } = (useStore as any)((state: DjStore) => state.actions);
+  const dragging = useRef(false);
+  const lastY = useRef(0);
+  const [isDragging, setIsDragging] = useState(false);
   
   const deckColor = deckId === 0 ? 'cyan' : 'red';
   const rotationSpeed = isPlaying ? (10 / pitch) : 0;
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    dragging.current = true;
+    lastY.current = e.clientY;
+    setIsDragging(true);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragging.current) return;
+    const delta = lastY.current - e.clientY;
+    lastY.current = e.clientY;
+    nudge(deckId, delta / 200);
+  };
+
+  const handlePointerUp = () => {
+    dragging.current = false;
+    nudge(deckId, 0);
+    setIsDragging(false);
+  };
   
   return (
-    <div className="relative w-48 h-48 md:w-56 md:h-56">
-      <div 
+    <div className="relative w-48 h-48 md:w-56 md:h-56" onPointerDown={handlePointerDown} onPointerMove={handlePointerMove} onPointerUp={handlePointerUp} onPointerLeave={handlePointerUp} style={{cursor: isDragging ? 'grabbing' : 'grab'}}>
+      <div
         className={`w-full h-full rounded-full bg-gray-800 border-4 border-gray-700 flex items-center justify-center transition-shadow duration-300 shadow-[0_0_15px_rgba(0,0,0,0.5)] ${isPlaying ? `shadow-${deckColor}-500/50` : ''}`}
       >
         <div
@@ -30,7 +53,7 @@ const JogWheel: React.FC<JogWheelProps> = ({ deckId, useStore }) => {
         </div>
         <div className="w-24 h-24 rounded-full bg-gray-900 flex flex-col items-center justify-center text-center p-1 z-10">
           <span className="text-xs text-gray-400 truncate w-full">{track ? track.name.split('.mp3')[0] : `Deck ${deckId + 1}`}</span>
-          <span className={`font-bold text-lg text-${deckColor}-400`}>{track ? (track.duration * (pitch/1.0-1)*100+100).toFixed(1)+"%" : "100.0%"}</span>
+          <span className={`font-bold text-lg text-${deckColor}-400`}>{track ? `${(bpm * pitch).toFixed(1)} BPM` : "0 BPM"}</span>
         </div>
       </div>
       <style>{`

--- a/app/components/player/Touchscreen.tsx
+++ b/app/components/player/Touchscreen.tsx
@@ -75,7 +75,7 @@ const Touchscreen: React.FC<TouchscreenProps> = ({ deckId, useStore }) => {
       </div>
       {track && (
         <div className="absolute top-2 right-2 text-xs text-white bg-black/50 p-1 rounded">
-          {Math.round(bpm)} BPM | {(pitch * 100).toFixed(1)}%
+          {Math.round(bpm * pitch)} BPM | {(pitch * 100).toFixed(1)}%
         </div>
       )}
       <div className="absolute bottom-2 right-2 text-lg font-mono font-bold text-white bg-black/50 p-1 rounded">

--- a/app/hooks/useDjEngine.ts
+++ b/app/hooks/useDjEngine.ts
@@ -25,6 +25,7 @@ const createInitialPlayerState = (): State['players'][0] => ({
   playbackTime: 0,
   volume: 1,
   pitch: 1.0,
+  pitchRange: 0.08,
   bpm: 120,
   hotCues: [],
   activeLoop: null,
@@ -140,6 +141,22 @@ const useStore = create<DjStore>()(
          });
          if(playerNodes[deckId].source){
              playerNodes[deckId].source!.playbackRate.value = pitch;
+         }
+      },
+      setPitchRange: (deckId, range) => {
+         set(state => {
+           state.players[deckId].pitchRange = range;
+           const value = Math.max(1 - range, Math.min(1 + range, state.players[deckId].pitch));
+           state.players[deckId].pitch = value;
+         });
+         if(playerNodes[deckId].source){
+             playerNodes[deckId].source!.playbackRate.value = get().players[deckId].pitch;
+         }
+      },
+      nudge: (deckId, delta) => {
+         const source = playerNodes[deckId].source;
+         if (source) {
+           source.playbackRate.value = get().players[deckId].pitch + delta;
          }
       },
       setVolume: (deckId, volume) => {

--- a/app/types.ts
+++ b/app/types.ts
@@ -24,6 +24,8 @@ export interface PlayerState {
   playbackTime: number;
   volume: number;
   pitch: number;
+  /** Maximum pitch deviation from 1.0 (0.08 = +-8%) */
+  pitchRange: number;
   bpm: number;
   hotCues: HotCue[];
   activeLoop: Loop | null;
@@ -65,6 +67,8 @@ export interface Actions {
   seek: (deckId: number, time: number) => void;
   setVolume: (deckId: number, volume: number) => void;
   setPitch: (deckId: number, pitch: number) => void;
+  setPitchRange: (deckId: number, range: number) => void;
+  nudge: (deckId: number, delta: number) => void;
   toggleSync: (deckId: number) => void;
   setHotCue: (deckId: number, cueId: number) => void;
   deleteHotCue: (deckId: number, cueId: number) => void;


### PR DESCRIPTION
## Summary
- add `pitchRange` to store and actions
- allow setting 8% or 16% range and adapt fader mapping
- show current BPM in touchscreen and jogwheel
- enable jogwheel mouse dragging to nudge playback

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d7b0e5088832e8c5d7237a97357be