### PR TITLE
Add advanced touch display

### DIFF
--- a/app/components/Player.tsx
+++ b/app/components/Player.tsx
@@ -1,5 +1,5 @@
 
-import React, { useRef, ChangeEvent } from 'react';
+import React, { useState } from 'react';
 import type { StoreApi } from 'zustand';
 import type { DjStore } from '../types';
 import Touchscreen from './player/Touchscreen';
@@ -16,17 +16,15 @@ const Player: React.FC<PlayerProps> = ({ deckId, useStore }) => {
   const { loadTrack, togglePlay, setPitch, setPitchRange, nudge, setHotCue, jumpToHotCue, deleteHotCue, setLoop, clearLoop, toggleSync, syncPlayers } =
     (useStore as any)((state: DjStore) => state.actions);
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [playlist, setPlaylist] = useState<File[]>([]);
 
-  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file) {
-      loadTrack(deckId, file);
-    }
+  const handleSelectTrack = (file: File) => {
+    loadTrack(deckId, file);
   };
 
-  const handleUploadClick = () => {
-    fileInputRef.current?.click();
+  const handleFileSelected = (file: File) => {
+    setPlaylist(p => [...p, file]);
+    loadTrack(deckId, file);
   };
 
   const deckColor = deckId === 0 ? 'cyan' : 'red';
@@ -47,7 +45,13 @@ const Player: React.FC<PlayerProps> = ({ deckId, useStore }) => {
 
   return (
     <div className="flex flex-col w-1/3 bg-gray-900/50 border border-gray-700 rounded-lg p-3 space-y-3">
-      <Touchscreen deckId={deckId} useStore={useStore} />
+      <Touchscreen
+        deckId={deckId}
+        useStore={useStore}
+        playlist={playlist}
+        onSelectTrack={handleSelectTrack}
+        onFileSelected={handleFileSelected}
+      />
       <div className="flex-grow flex items-center justify-center gap-2">
         <JogWheel deckId={deckId} useStore={useStore} />
         <div className="h-48 flex flex-col items-center">
@@ -129,19 +133,6 @@ const Player: React.FC<PlayerProps> = ({ deckId, useStore }) => {
         >
           <i className="fa fa-sync"></i>
         </button>
-        <button
-            onClick={handleUploadClick}
-            className="w-1/4 py-4 rounded bg-gray-800 hover:bg-gray-700 border border-gray-600 text-lg"
-        >
-            <i className="fa fa-upload"></i>
-        </button>
-        <input
-            type="file"
-            ref={fileInputRef}
-            onChange={handleFileChange}
-            accept=".mp3"
-            className="hidden"
-        />
       </div>
     </div>
   );

--- a/app/components/player/Touchscreen.tsx
+++ b/app/components/player/Touchscreen.tsx
@@ -1,23 +1,72 @@
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState, ChangeEvent } from 'react';
 import type { StoreApi } from 'zustand';
 import type { DjStore } from '../../types';
 
 interface TouchscreenProps {
   deckId: number;
   useStore: StoreApi<DjStore>;
+  playlist: File[];
+  onSelectTrack: (file: File) => void;
+  onFileSelected: (file: File) => void;
 }
 
-const Touchscreen: React.FC<TouchscreenProps> = ({ deckId, useStore }) => {
+const Touchscreen: React.FC<TouchscreenProps> = ({ deckId, useStore, playlist, onSelectTrack, onFileSelected }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const playerState = (useStore as any)((state: DjStore) => state.players[deckId]);
-  const { track, playbackTime, bpm, pitch } = playerState;
+  const { track, playbackTime, bpm, pitch, isSync } = playerState;
+  const { seek, setLoop, clearLoop } = (useStore as any)((state: DjStore) => state.actions);
   const deckColor = deckId === 0 ? '#06b6d4' : '#f43f5e'; // cyan-500, red-500
+  const [zoom, setZoom] = useState(1);
+  const [showPlaylist, setShowPlaylist] = useState(false);
+
+  const handleZoomIn = () => setZoom(z => Math.min(4, z + 0.5));
+  const handleZoomOut = () => setZoom(z => Math.max(1, z - 0.5));
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) onFileSelected(file);
+  };
+
+  const handleBeatJump = (beats: number) => {
+    if (!track) return;
+    const beatLen = 60 / bpm;
+    let newTime = playbackTime + beats * beatLen;
+    newTime = Math.max(0, Math.min(newTime, track.duration));
+    seek(deckId, newTime);
+  };
+
+  const handleLoopSet = (beats: number) => {
+    if (!track) return;
+    const beatLen = 60 / bpm;
+    const start = playbackTime;
+    const end = start + beats * beatLen;
+    setLoop(deckId, start, end);
+  };
+
+  const handleClearLoop = () => clearLoop(deckId);
+
+  const openFileDialog = () => fileInputRef.current?.click();
+
+  const handleSeek = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!track) return;
+    const rect = canvasRef.current!.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const total = track.waveform.length;
+    const visible = Math.floor(total / zoom);
+    const playPos = (playbackTime / track.duration) * total;
+    const start = Math.max(0, Math.min(total - visible, Math.floor(playPos - visible / 2)));
+    const percent = x / rect.width;
+    const sample = start + percent * visible;
+    const time = (sample / total) * track.duration;
+    seek(deckId, time);
+  };
 
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas || !track) return;
-    
+
     const context = canvas.getContext('2d');
     if (!context) return;
     
@@ -27,27 +76,43 @@ const Touchscreen: React.FC<TouchscreenProps> = ({ deckId, useStore }) => {
       const { width, height } = canvas;
       context.fillStyle = '#111827'; // gray-900
       context.fillRect(0, 0, width, height);
-      
+
       if (track.waveform.length > 0) {
-        const step = width / track.waveform.length;
+        const total = track.waveform.length;
+        const visible = Math.floor(total / zoom);
+        const playPos = (playbackTime / track.duration) * total;
+        const start = Math.max(0, Math.min(total - visible, Math.floor(playPos - visible / 2)));
+        const end = start + visible;
+        const step = width / (end - start);
         const middle = height / 2;
-        
+
         context.strokeStyle = deckColor;
         context.lineWidth = 2;
-        
+
         context.beginPath();
-        track.waveform.forEach((val, i) => {
-          const x = i * step;
+        for (let i = start; i < end; i++) {
+          const val = track.waveform[i];
+          const x = (i - start) * step;
           const y = val * middle;
           context.moveTo(x, middle - y);
           context.lineTo(x, middle + y);
-        });
+        }
         context.stroke();
+
+        // Hot cues
+        playerState.hotCues.forEach(cue => {
+          const cuePos = (cue.time / track.duration) * total;
+          if (cuePos >= start && cuePos <= end) {
+            const x = (cuePos - start) * step;
+            context.fillStyle = deckColor;
+            context.fillRect(x - 1, 0, 2, height);
+          }
+        });
       }
-      
+
       const progress = playbackTime / track.duration;
       const playheadX = progress * width;
-      
+
       context.fillStyle = 'rgba(255, 255, 255, 0.8)';
       context.fillRect(playheadX, 0, 2, height);
 
@@ -59,7 +124,7 @@ const Touchscreen: React.FC<TouchscreenProps> = ({ deckId, useStore }) => {
     return () => {
       cancelAnimationFrame(animationFrameId);
     };
-  }, [track, playbackTime, deckColor]);
+  }, [track, playbackTime, deckColor, zoom, playerState.hotCues]);
 
   const formatTime = (time: number) => {
     const minutes = Math.floor(time / 60);
@@ -68,19 +133,70 @@ const Touchscreen: React.FC<TouchscreenProps> = ({ deckId, useStore }) => {
   };
 
   return (
-    <div className="w-full h-48 bg-gray-900 rounded-md p-2 relative border border-gray-700">
-      <canvas ref={canvasRef} className="w-full h-full" width="500" height="150" />
-      <div className="absolute top-2 left-2 text-xs text-white bg-black/50 p-1 rounded">
+    <div className="w-full h-60 bg-gray-900 rounded-md p-2 relative border border-gray-700">
+      <canvas
+        ref={canvasRef}
+        className="w-full h-full"
+        width="600"
+        height="200"
+        onPointerDown={handleSeek}
+      />
+      <div className="absolute top-1 left-2 text-xs text-white bg-black/50 px-1 rounded">
         {track ? track.name : 'No Track Loaded'}
       </div>
       {track && (
-        <div className="absolute top-2 right-2 text-xs text-white bg-black/50 p-1 rounded">
-          {Math.round(bpm * pitch)} BPM | {(pitch * 100).toFixed(1)}%
+        <div className="absolute top-1 right-2 text-xs text-white bg-black/50 px-1 rounded flex items-center gap-1">
+          {Math.round(bpm * pitch)} BPM | {(pitch * 100).toFixed(1)}% | {track.bitrate} kbps
+          {isSync && <i className="fa fa-link text-cyan-400"></i>}
         </div>
       )}
-      <div className="absolute bottom-2 right-2 text-lg font-mono font-bold text-white bg-black/50 p-1 rounded">
+      {track && (
+        <div className="absolute bottom-8 left-2 text-xs text-white bg-black/50 px-1 rounded">
+          Key: {track.key || '--'}
+        </div>
+      )}
+      <div className="absolute bottom-2 right-2 text-lg font-mono font-bold text-white bg-black/50 px-1 rounded">
         {track ? `${formatTime(playbackTime)} / ${formatTime(track.duration)}` : '0:00 / 0:00'}
       </div>
+      <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex gap-1">
+        <button onClick={handleZoomOut} className="px-2 py-1 text-xs bg-gray-700 rounded hover:bg-gray-600">-</button>
+        <button onClick={handleZoomIn} className="px-2 py-1 text-xs bg-gray-700 rounded hover:bg-gray-600">+</button>
+        <button onClick={() => handleBeatJump(-1)} className="px-2 py-1 text-xs bg-gray-700 rounded hover:bg-gray-600">&#171;</button>
+        <button onClick={() => handleBeatJump(1)} className="px-2 py-1 text-xs bg-gray-700 rounded hover:bg-gray-600">&#187;</button>
+      </div>
+      <div className="absolute bottom-10 left-1/2 -translate-x-1/2 flex gap-1">
+        {[1,2,4].map(b => (
+          <button key={b} onClick={() => handleLoopSet(b)} className="px-2 py-1 text-xs bg-gray-700 rounded hover:bg-gray-600">{b}B</button>
+        ))}
+        <button onClick={handleClearLoop} className="px-2 py-1 text-xs bg-gray-700 rounded hover:bg-gray-600">CLR</button>
+      </div>
+      <button
+        onClick={() => setShowPlaylist(!showPlaylist)}
+        className="absolute top-1/2 right-2 -translate-y-1/2 text-xs bg-gray-700 px-2 py-1 rounded hover:bg-gray-600"
+      >
+        <i className="fa fa-bars"></i>
+      </button>
+      <input type="file" ref={fileInputRef} onChange={handleFileChange} accept=".mp3" className="hidden" />
+      {showPlaylist && (
+        <div className="absolute inset-0 bg-black/80 p-2 rounded-md flex flex-col">
+          <div className="flex justify-between items-center mb-2">
+            <span className="text-white text-sm font-bold">Playlist</span>
+            <button onClick={() => setShowPlaylist(false)} className="text-white text-sm">X</button>
+          </div>
+          <div className="flex-1 overflow-y-auto space-y-1">
+            {playlist.map((file, i) => (
+              <div
+                key={i}
+                onClick={() => { onSelectTrack(file); setShowPlaylist(false); }}
+                className="p-1 bg-gray-700 text-white rounded cursor-pointer hover:bg-gray-600"
+              >
+                {file.name}
+              </div>
+            ))}
+          </div>
+          <button onClick={openFileDialog} className="mt-2 py-1 bg-gray-600 text-white rounded">Add Track</button>
+        </div>
+      )}
     </div>
   );
 };

--- a/app/hooks/useDjEngine.ts
+++ b/app/hooks/useDjEngine.ts
@@ -86,6 +86,7 @@ const useStore = create<DjStore>()(
         playerNodes[deckId].source = null;
         const arrayBuffer = await file.arrayBuffer();
         const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+        const bitrate = Math.round((file.size * 8) / (audioBuffer.duration * 1000));
         const waveform = processAudioBuffer(audioBuffer);
         let bpm = 120;
         try {
@@ -101,6 +102,9 @@ const useStore = create<DjStore>()(
             waveform,
             duration: audioBuffer.duration,
             bpm,
+            bitrate,
+            key: undefined,
+            artwork: undefined,
           };
           state.players[deckId].playbackTime = 0;
           state.players[deckId].isPlaying = false;

--- a/app/types.ts
+++ b/app/types.ts
@@ -6,6 +6,12 @@ export interface Track {
   waveform: number[];
   duration: number;
   bpm: number;
+  /** Estimated audio bitrate in kbps */
+  bitrate: number;
+  /** Musical key of the track if detected */
+  key?: string;
+  /** Optional artwork URL extracted from metadata */
+  artwork?: string;
 }
 
 export interface HotCue {


### PR DESCRIPTION
## Summary
- expand `Track` interface with bitrate, key and artwork metadata
- calculate bitrate when loading tracks
- store playlist in Player and pass it to display
- overhaul `Touchscreen` with zoom, playlist overlay and beat controls

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d7c7b5828832ea8a425133de9a103