### PR TITLE
Add central display with dual waveform

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import Player from './components/Player';
 import Mixer from './components/Mixer';
+import { CentralDisplay } from './components/CentralDisplay';
 import useDjEngine from './hooks/useDjEngine';
 import type { DjStore } from './types';
 
@@ -90,10 +91,13 @@ const App: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gray-900 bg-opacity-90 bg-[radial-gradient(#111_1px,transparent_1px)] [background-size:16px_16px] text-white flex flex-col items-center justify-center p-2 font-sans overflow-hidden">
-      <div className="w-full max-w-[1800px] flex justify-between gap-2 p-4 bg-black/50 rounded-xl border border-gray-700 shadow-2xl shadow-cyan-500/10">
-        <Player deckId={0} useStore={store} />
-        <Mixer useStore={store} />
-        <Player deckId={1} useStore={store} />
+      <div className="w-full max-w-[1800px] flex flex-col items-center gap-2 p-4 bg-black/50 rounded-xl border border-gray-700 shadow-2xl shadow-cyan-500/10">
+        <CentralDisplay useStore={store} />
+        <div className="w-full flex justify-between gap-2">
+          <Player deckId={0} useStore={store} />
+          <Mixer useStore={store} />
+          <Player deckId={1} useStore={store} />
+        </div>
       </div>
       <footer className="text-gray-500 text-xs mt-4">
           <p>AI DJ Mix Console. Based on Pioneer DJ CDJ-3000 & DJM-A9. Keyboard controls are active.</p>

--- a/app/components/CentralDisplay/CentralDisplay.tsx
+++ b/app/components/CentralDisplay/CentralDisplay.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import type { StoreApi } from 'zustand';
+import type { DjStore } from '../../types';
+import TrackInfo from './TrackInfo';
+import DualWaveform from './DualWaveform';
+
+interface Props {
+  useStore: StoreApi<DjStore>;
+}
+
+const CentralDisplay: React.FC<Props> = ({ useStore }) => (
+  <div className="w-full bg-gray-900/70 border border-gray-700 rounded-md p-2 mb-2 space-y-2">
+    <TrackInfo deck="left" useStore={useStore} />
+    <DualWaveform useStore={useStore} />
+    <TrackInfo deck="right" useStore={useStore} />
+  </div>
+);
+
+export default CentralDisplay;

--- a/app/components/CentralDisplay/DualWaveform.tsx
+++ b/app/components/CentralDisplay/DualWaveform.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useRef } from 'react';
+import type { StoreApi } from 'zustand';
+import type { DjStore } from '../../types';
+
+interface Props {
+  useStore: StoreApi<DjStore>;
+}
+
+const drawWave = (
+  canvas: HTMLCanvasElement,
+  waveform: number[],
+  progress: number,
+  color: string
+) => {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  const { width, height } = canvas;
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = '#1f2937';
+  ctx.fillRect(0, 0, width, height);
+  if (waveform.length) {
+    const step = width / waveform.length;
+    ctx.strokeStyle = color;
+    ctx.beginPath();
+    for (let i = 0; i < waveform.length; i++) {
+      const val = waveform[i];
+      const x = i * step;
+      const y = (1 - val) * (height / 2);
+      ctx.moveTo(x, y);
+      ctx.lineTo(x, height - y);
+    }
+    ctx.stroke();
+  }
+  ctx.fillStyle = 'rgba(255,255,255,0.8)';
+  const x = progress * width;
+  ctx.fillRect(x, 0, 2, height);
+};
+
+const DualWaveform: React.FC<Props> = ({ useStore }) => {
+  const canvasLeft = useRef<HTMLCanvasElement>(null);
+  const canvasRight = useRef<HTMLCanvasElement>(null);
+  const [left, right] = (useStore as any)((s: DjStore) => [s.players[0], s.players[1]]);
+
+  useEffect(() => {
+    if (canvasLeft.current && left.track) {
+      drawWave(
+        canvasLeft.current,
+        left.track.waveform,
+        left.playbackTime / left.track.duration,
+        '#06b6d4'
+      );
+    }
+    if (canvasRight.current && right.track) {
+      drawWave(
+        canvasRight.current,
+        right.track.waveform,
+        right.playbackTime / right.track.duration,
+        '#f43f5e'
+      );
+    }
+  }, [left, right]);
+
+  return (
+    <div className="flex w-full gap-1 items-center">
+      <canvas ref={canvasLeft} className="flex-1 h-20 bg-gray-800 rounded" width={400} height={80} />
+      <canvas ref={canvasRight} className="flex-1 h-20 bg-gray-800 rounded" width={400} height={80} />
+    </div>
+  );
+};
+
+export default DualWaveform;

--- a/app/components/CentralDisplay/TrackInfo.tsx
+++ b/app/components/CentralDisplay/TrackInfo.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import type { StoreApi } from 'zustand';
+import type { DjStore } from '../../types';
+
+interface Props {
+  deck: 'left' | 'right';
+  useStore: StoreApi<DjStore>;
+}
+
+const TrackInfo: React.FC<Props> = ({ deck, useStore }) => {
+  const deckId = deck === 'left' ? 0 : 1;
+  const state = (useStore as any)((s: DjStore) => s.players[deckId]);
+  const { track, playbackTime, bpm, pitch, activeLoop } = state;
+
+  const formatTime = (time: number) => {
+    const m = Math.floor(time / 60);
+    const s = Math.floor(time % 60);
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  };
+
+  return (
+    <div className="flex justify-between text-xs text-gray-300 w-full px-2">
+      <span className="truncate mr-2">
+        {track ? track.name.split('.mp3')[0] : `Deck ${deckId + 1}`}
+      </span>
+      {track && (
+        <span className="flex gap-2">
+          <span>{formatTime(playbackTime)} / {formatTime(track.duration)}</span>
+          <span>{Math.round(bpm * pitch)} BPM</span>
+          {track.key && <span>Key: {track.key}</span>}
+          {activeLoop && <span>Loop</span>}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default TrackInfo;

--- a/app/components/CentralDisplay/index.ts
+++ b/app/components/CentralDisplay/index.ts
@@ -1,0 +1,3 @@
+export { default as CentralDisplay } from './CentralDisplay';
+export { default as TrackInfo } from './TrackInfo';
+export { default as DualWaveform } from './DualWaveform';

--- a/app/components/Player.tsx
+++ b/app/components/Player.tsx
@@ -1,8 +1,7 @@
 
-import React, { useState } from 'react';
+import React, { useRef, ChangeEvent } from 'react';
 import type { StoreApi } from 'zustand';
 import type { DjStore } from '../types';
-import Touchscreen from './player/Touchscreen';
 import JogWheel from './player/JogWheel';
 import Fader from './ui/Fader';
 
@@ -13,18 +12,16 @@ interface PlayerProps {
 
 const Player: React.FC<PlayerProps> = ({ deckId, useStore }) => {
   const playerState = (useStore as any)((state: DjStore) => state.players[deckId]);
-  const { loadTrack, togglePlay, setPitch, setPitchRange, nudge, setHotCue, jumpToHotCue, deleteHotCue, setLoop, clearLoop, toggleSync, syncPlayers } =
+  const { loadTrack, togglePlay, setPitch, setPitchRange, setHotCue, jumpToHotCue, deleteHotCue, setLoop, clearLoop, toggleSync, syncPlayers } =
     (useStore as any)((state: DjStore) => state.actions);
 
-  const [playlist, setPlaylist] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const handleSelectTrack = (file: File) => {
-    loadTrack(deckId, file);
-  };
-
-  const handleFileSelected = (file: File) => {
-    setPlaylist(p => [...p, file]);
-    loadTrack(deckId, file);
+  const handleFileSelected = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      loadTrack(deckId, file);
+    }
   };
 
   const deckColor = deckId === 0 ? 'cyan' : 'red';
@@ -45,13 +42,19 @@ const Player: React.FC<PlayerProps> = ({ deckId, useStore }) => {
 
   return (
     <div className="flex flex-col w-1/3 bg-gray-900/50 border border-gray-700 rounded-lg p-3 space-y-3">
-      <Touchscreen
-        deckId={deckId}
-        useStore={useStore}
-        playlist={playlist}
-        onSelectTrack={handleSelectTrack}
-        onFileSelected={handleFileSelected}
-      />
+      <div className="flex justify-center">
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          className="px-3 py-1 text-xs bg-gray-700 rounded hover:bg-gray-600"
+        >Load Track</button>
+        <input
+          type="file"
+          accept=".mp3"
+          ref={fileInputRef}
+          onChange={handleFileSelected}
+          className="hidden"
+        />
+      </div>
       <div className="flex-grow flex items-center justify-center gap-2">
         <JogWheel deckId={deckId} useStore={useStore} />
         <div className="h-48 flex flex-col items-center">


### PR DESCRIPTION
## Summary
- create new `CentralDisplay` component with track info and dual waveforms
- update `Player` to remove per‑deck touchscreen and add simple track loader
- reorganise layout in `App` so players and mixer sit below the new display

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d88d5a890832e8fd89763de156ed6