### PR TITLE
Fix DualWaveform hook usage

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -6,11 +6,11 @@ import useDjEngine from "./hooks/useDjEngine";
 import type { DjStore } from "./types";
 
 const App: React.FC = () => {
-  const { store, isReady } = useDjEngine();
+  const { useStore, isReady } = useDjEngine();
 
   useEffect(() => {
     const init = () => {
-      store.getState().actions.initAudio();
+      useStore.getState().actions.initAudio();
       window.removeEventListener("pointerdown", init);
       window.removeEventListener("keydown", init);
     };
@@ -24,8 +24,8 @@ const App: React.FC = () => {
 
   const handleKeydown = useCallback(
     (e: KeyboardEvent) => {
-      const { actions, activeChannel } = store.getState();
-      const { players, mixer } = store.getState();
+      const { actions, activeChannel } = useStore.getState();
+      const { players, mixer } = useStore.getState();
 
       // Prevent browser shortcuts
       if (e.key === " " || e.key === "Tab" || e.key.startsWith("Arrow")) {
@@ -126,11 +126,11 @@ const App: React.FC = () => {
   return (
     <div className="min-h-screen bg-gray-900 bg-opacity-90 bg-[radial-gradient(#111_1px,transparent_1px)] [background-size:16px_16px] text-white flex flex-col items-center justify-center p-2 font-sans overflow-hidden">
       <div className="w-full max-w-[1800px] flex flex-col items-center gap-2 p-4 bg-black/50 rounded-xl border border-gray-700 shadow-2xl shadow-cyan-500/10">
-        <CentralDisplay useStore={store} />
+        <CentralDisplay useStore={useStore} />
         <div className="w-full flex justify-between gap-2">
-          <Player deckId={0} useStore={store} />
-          <Mixer useStore={store} />
-          <Player deckId={1} useStore={store} />
+          <Player deckId={0} useStore={useStore} />
+          <Mixer useStore={useStore} />
+          <Player deckId={1} useStore={useStore} />
         </div>
       </div>
       <footer className="text-gray-500 text-xs mt-4">

--- a/app/components/CentralDisplay/CentralDisplay.tsx
+++ b/app/components/CentralDisplay/CentralDisplay.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import type { StoreApi } from 'zustand';
+import type { UseBoundStore } from 'zustand';
 import type { DjStore } from '../../types';
 import TrackInfo from './TrackInfo';
 import DualWaveform from './DualWaveform';
 
 interface Props {
-  useStore: StoreApi<DjStore>;
+  useStore: UseBoundStore<DjStore>;
 }
 
 const CentralDisplay: React.FC<Props> = ({ useStore }) => (

--- a/app/components/CentralDisplay/DualWaveform.tsx
+++ b/app/components/CentralDisplay/DualWaveform.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef } from 'react';
-import type { StoreApi } from 'zustand';
+import type { UseBoundStore } from 'zustand';
 import type { DjStore } from '../../types';
 
 interface Props {
-  useStore: StoreApi<DjStore>;
+  useStore: UseBoundStore<DjStore>;
 }
 
 const drawWave = (

--- a/app/components/CentralDisplay/TrackInfo.tsx
+++ b/app/components/CentralDisplay/TrackInfo.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import type { StoreApi } from 'zustand';
+import type { UseBoundStore } from 'zustand';
 import type { DjStore } from '../../types';
 
 interface Props {
   deck: 'left' | 'right';
-  useStore: StoreApi<DjStore>;
+  useStore: UseBoundStore<DjStore>;
 }
 
 const TrackInfo: React.FC<Props> = ({ deck, useStore }) => {

--- a/app/components/Clock/MasterClock.tsx
+++ b/app/components/Clock/MasterClock.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import type { StoreApi } from 'zustand';
+import type { UseBoundStore } from 'zustand';
 import type { DjStore } from '../../types';
 
 interface Props {
-  useStore: StoreApi<DjStore>;
+  useStore: UseBoundStore<DjStore>;
 }
 
 const MasterClock: React.FC<Props> = ({ useStore }) => {

--- a/app/components/Mixer.tsx
+++ b/app/components/Mixer.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import type { StoreApi } from 'zustand';
+import type { UseBoundStore } from 'zustand';
 import type { DjStore } from '../types';
 import ChannelStrip from './mixer/ChannelStrip';
 import MasterChannel from './mixer/MasterChannel';
@@ -9,7 +9,7 @@ import Fader from './ui/Fader';
 import MasterClock from './Clock/MasterClock';
 
 interface MixerProps {
-  useStore: StoreApi<DjStore>;
+  useStore: UseBoundStore<DjStore>;
 }
 
 const Mixer: React.FC<MixerProps> = ({ useStore }) => {

--- a/app/components/Player.tsx
+++ b/app/components/Player.tsx
@@ -1,13 +1,13 @@
 
 import React, { useRef, ChangeEvent } from 'react';
-import type { StoreApi } from 'zustand';
+import type { UseBoundStore } from 'zustand';
 import type { DjStore } from '../types';
 import JogWheel from './player/JogWheel';
 import Fader from './ui/Fader';
 
 interface PlayerProps {
   deckId: number;
-  useStore: StoreApi<DjStore>;
+  useStore: UseBoundStore<DjStore>;
 }
 
 const Player: React.FC<PlayerProps> = ({ deckId, useStore }) => {

--- a/app/components/mixer/BeatFxPanel.tsx
+++ b/app/components/mixer/BeatFxPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { StoreApi } from 'zustand';
+import type { UseBoundStore } from 'zustand';
 import type { DjStore } from '../../types';
 import Fader from '../ui/Fader';
 
@@ -10,7 +10,7 @@ const effects = [
 ];
 
 interface Props {
-  useStore: StoreApi<DjStore>;
+  useStore: UseBoundStore<DjStore>;
 }
 
 const BeatFxPanel: React.FC<Props> = ({ useStore }) => {

--- a/app/components/mixer/ChannelStrip.tsx
+++ b/app/components/mixer/ChannelStrip.tsx
@@ -1,13 +1,13 @@
 
 import React from 'react';
-import type { StoreApi } from 'zustand';
+import type { UseBoundStore } from 'zustand';
 import type { DjStore } from '../../types';
 import Knob from '../ui/Knob';
 import Fader from '../ui/Fader';
 
 interface ChannelStripProps {
   channelId: number;
-  useStore: StoreApi<DjStore>;
+  useStore: UseBoundStore<DjStore>;
   deckColor: 'cyan' | 'red';
 }
 

--- a/app/components/mixer/MasterChannel.tsx
+++ b/app/components/mixer/MasterChannel.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import type { StoreApi } from 'zustand';
+import type { UseBoundStore } from 'zustand';
 import type { DjStore } from '../../types';
 import Knob from '../ui/Knob';
 import Fader from '../ui/Fader';
 
 interface Props {
-  useStore: StoreApi<DjStore>;
+  useStore: UseBoundStore<DjStore>;
 }
 
 const MasterChannel: React.FC<Props> = ({ useStore }) => {

--- a/app/components/player/JogWheel.tsx
+++ b/app/components/player/JogWheel.tsx
@@ -1,11 +1,11 @@
 
 import React, { useRef, useState } from 'react';
-import type { StoreApi } from 'zustand';
+import type { UseBoundStore } from 'zustand';
 import type { DjStore } from '../../types';
 
 interface JogWheelProps {
   deckId: number;
-  useStore: StoreApi<DjStore>;
+  useStore: UseBoundStore<DjStore>;
 }
 
 const JogWheel: React.FC<JogWheelProps> = ({ deckId, useStore }) => {

--- a/app/components/player/Touchscreen.tsx
+++ b/app/components/player/Touchscreen.tsx
@@ -1,11 +1,11 @@
 
 import React, { useEffect, useRef, useState, ChangeEvent } from 'react';
-import type { StoreApi } from 'zustand';
+import type { UseBoundStore } from 'zustand';
 import type { DjStore } from '../../types';
 
 interface TouchscreenProps {
   deckId: number;
-  useStore: StoreApi<DjStore>;
+  useStore: UseBoundStore<DjStore>;
   playlist: File[];
   onSelectTrack: (file: File) => void;
   onFileSelected: (file: File) => void;

--- a/app/hooks/useDjEngine.ts
+++ b/app/hooks/useDjEngine.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { create, StoreApi } from 'zustand';
+import { create, StoreApi, UseBoundStore } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import type { DjStore, State, FXState } from '../types';
 import { processAudioBuffer } from '../utils/audioUtils';
@@ -548,7 +548,7 @@ const useDjEngine = () => {
 
   return {
     store: useStore as StoreApi<DjStore>,
-    useStore,
+    useStore: useStore as UseBoundStore<DjStore>,
     isReady: !!audioContext,
   };
 };


### PR DESCRIPTION
## Summary
- use `UseBoundStore` typing for props expecting the store hook
- return `useStore` as `UseBoundStore` in engine hook

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687db7b034a0832e870143deb69c8f51